### PR TITLE
Updated to make use of the version 1.0.0 to use an options object

### DIFF
--- a/develop/add_feature_layers_leaflet.md
+++ b/develop/add_feature_layers_leaflet.md
@@ -20,7 +20,7 @@ In this lab, you will add a feature layer to an Esri Leaflet application.
 		L.esri.basemapLayer('DarkGray').addTo(map);
 
 		 // ADD the rail lines here
-		L.esri.featureLayer('http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Rail_Lines_Styled/FeatureServer/0').addTo(map);
+		L.esri.featureLayer({ url: 'http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Rail_Lines_Styled/FeatureServer/0'}).addTo(map);
 
 	</script>
 	```

--- a/develop/src/add_feature_layers_leaflet.html
+++ b/develop/src/add_feature_layers_leaflet.html
@@ -28,11 +28,11 @@
     L.esri.basemapLayer('DarkGray').addTo(map);
 
     // Load layers in order
-    L.esri.featureLayer('http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Neighborhoods_Styled/FeatureServer/0').on('load', function() {
+    L.esri.featureLayer({ url: 'http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Neighborhoods_Styled/FeatureServer/0'}).on('load', function() {
 
-        L.esri.featureLayer('http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Rail_Lines_Styled/FeatureServer/0').on('load', function() {
+        L.esri.featureLayer({ url: 'http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Rail_Lines_Styled/FeatureServer/0'}).on('load', function() {
 
-            L.esri.featureLayer('http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Rail_Stops_Styled/FeatureServer/0').addTo(map);
+            L.esri.featureLayer({ url: 'http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Rail_Stops_Styled/FeatureServer/0'}).addTo(map);
 
         }).addTo(map);
 


### PR DESCRIPTION
Rather than the direct url parameter of pre-1.0.0 releases.

See [Release Notes](https://github.com/Esri/esri-leaflet/releases/tag/v1.0.0)
