### PR TITLE
need to bump to leaflet 1.0 beta to match new live docs

### DIFF
--- a/develop/build_starter_map_leaflet.md
+++ b/develop/build_starter_map_leaflet.md
@@ -17,11 +17,11 @@ If you are new to Esri-Leafet you can get the examples and API documentation [he
       <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
       <!-- Load Leaflet from CDN-->
-      <link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.css" />
-      <script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
+      <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet/v1.0.0-beta.2/leaflet.css" />
+      <script src="//cdn.leafletjs.com/leaflet/v1.0.0-beta.2/leaflet.js"></script>
 
       <!-- Load Esri Leaflet from CDN -->
-      <script src="//cdn.jsdelivr.net/leaflet.esri/1.0.2/esri-leaflet.js"></script>
+      <script src="//cdn.jsdelivr.net/leaflet.esri/2.0.0-beta.7/esri-leaflet.js"></script>
 
       <style>
         body {margin:0;padding:0;}

--- a/develop/locate_query_leaflet.md
+++ b/develop/locate_query_leaflet.md
@@ -19,7 +19,7 @@ Use Leaflet's built in [method](http://leafletjs.com/reference.html#map-set-meth
 
 > ### 3. Then we ask our ArcGIS service which census block they're inside of.
 
-Create an [`L.esri.Tasks.query`](http://esri.github.io/esri-leaflet/api-reference/tasks/query.html) object and pass it the user's location.  afterwards you'll be able to fire a request to an Esri service that hosts [US Census Block Groups](http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/1) to see which block the person is inside.
+Create an [`L.esri.query`](http://esri.github.io/esri-leaflet/api-reference/tasks/query.html) object and pass it the user's location.  afterwards you'll be able to fire a request to an Esri service that hosts [US Census Block Groups](http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/1) to see which block the person is inside.
 
 > ### 4. ... and draw the right one.
 

--- a/develop/locate_turf_leaflet.md
+++ b/develop/locate_turf_leaflet.md
@@ -1,6 +1,6 @@
 # Use HTML5 location, esri leaflet and turf to query a feature service
 
-In this lab we'll write a [Leaflet](https://leafletjs.com) application that uses [HTML5](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5) to glean a user's location and display the census block they happen to be inside.
+In this lab we'll write a [Leaflet](https://leafletjs.com) application that uses [HTML5](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5) to glean a user's location and then take advantage of Turf to figure out what census block they happen to be inside.
 
 > ### 1. First lets get our development environment set up.
 
@@ -19,7 +19,7 @@ Use Leaflet's built in [method](http://leafletjs.com/reference.html#map-set-meth
 
 > ### 3. Lets add census blocks to the map too (but not draw them *yet*).
 
-Add [US Census Block Groups](http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/1) to the map in a [`L.esri.Layers.featureLayer`](http://esri.github.io/esri-leaflet/api-reference/layers/feature-layer.html) and make sure the symbology is transparent (for now).
+Add [US Census Block Groups](http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/1) to the map in a [`L.esri.featureLayer`](http://esri.github.io/esri-leaflet/api-reference/layers/feature-layer.html) and make sure the symbology is transparent (for now).
 
 > ### 4. Use [turf](http://turfjs.org/) to see which census block the user is inside.
 
@@ -33,9 +33,7 @@ Last, lets refresh the symbology of the features in the map to make sure the mat
 
 ![step-4](./html5_query_step_4_leaflet.png)
 
-In the end, hopefully your app will look *kinda, sorta* like:
-
-> ##### [**this**](http://bl.ocks.org/jgravois/89a3781d01b2bf747cef)
+In the end, hopefully your app will look *kinda, sorta* like [**this**](http://bl.ocks.org/jgravois/89a3781d01b2bf747cef).
 
 ---
 ### Resources
@@ -49,6 +47,6 @@ In the end, hopefully your app will look *kinda, sorta* like:
 > are you thirsty for more?
 
 * add some custom styling to the census block thats drawn
-* display a popup with its ID when someone clicks on it
-* symbolize the actual user location
-* use [Geoenrichment](https://developers.arcgis.com/en/features/geo-enrichment/) and display the total population of the census block
+* display a popup with information about the census block
+* symbolize the actual user location on the map
+* use [Geoenrichment](https://developers.arcgis.com/en/features/geo-enrichment/) to query/display the total population of the census block


### PR DESCRIPTION
argh...
i just realized that since the namespaces have been shortened/simplified/changed in our new [`2.x`](https://github.com/Esri/esri-leaflet/blob/master/CHANGELOG.md#200-beta4) beta and the new doc is already live, it will make it a lot easier on the students if we bumped the tutorials to match.
