### PR TITLE
Update references to match the correct starter-map

### DIFF
--- a/develop/add_feature_layer_jsapi.md
+++ b/develop/add_feature_layer_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you will add a feature layer to an ArcGIS API for JavaScript application. 
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/add_feature_layers_jsapi.md
+++ b/develop/add_feature_layers_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you will add a feature layer to an ArcGIS API for JavaScript application. 
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/add_geojson_layer_jsapi.md
+++ b/develop/add_geojson_layer_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you'll learn an easy way to load GeoJSON directly into your ArcGIS map.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, load the [Esri Terraformer](https://github.com/Esri/Terraformer) libraries within in the `<head>` tag, anywhere before the main `<script>` tag.
 

--- a/develop/add_vector_tile_layer_jsapi.md
+++ b/develop/add_vector_tile_layer_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you will add a vector tile layer to an ArcGIS API for JavaScript application. 
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/create_a_web_map_app.md
+++ b/develop/create_a_web_map_app.md
@@ -4,7 +4,7 @@ You can use the [ArcGIS API for JavaScript](https://developers.arcgis.com/javasc
 
 In this lab, you will use the ArcGIS JS 3.x API to load a map by a `WebmapID` in a custom JavaScript app. Feel free to visit [this tutorial](https://developers.arcgis.com/javascript/jshelp/intro_agstemplate_amd.html) for more information.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/feature_layer_search_jsapi.md
+++ b/develop/feature_layer_search_jsapi.md
@@ -4,7 +4,7 @@ In this lab you will add a search widget search against a feature layer. The wid
 
 In this lab it will search against the neighborhood polygon layer.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/geometry_engine_buffer_jsapi.md
+++ b/develop/geometry_engine_buffer_jsapi.md
@@ -4,7 +4,7 @@ In this lab you will use the GeometryEngine to buffer around Rail Stops in the b
 
 You will add an interactive slider and a feedback label to the UI that will be used when changing the size of the buffer.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, add the buffer UI `div` element and its contents:
 

--- a/develop/geometry_engine_fixed_buffer_jsapi.md
+++ b/develop/geometry_engine_fixed_buffer_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you will use the GeometryEngine to buffer around Rail Stops in the browser by a fixed amount.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/query_feature_layer_jsapi.md
+++ b/develop/query_feature_layer_jsapi.md
@@ -4,7 +4,7 @@ In this lab you will use a QueryTask to query data from a feature layer.
 
 You will create a simple widget in the UI to change the query selection.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, add the query drop-down menue UI `div` element and its contents:
 

--- a/develop/simple_search_jsapi.md
+++ b/develop/simple_search_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you will add a basic search widget to your app.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/smartmapping_color_renderer_jsapi.md
+++ b/develop/smartmapping_color_renderer_jsapi.md
@@ -6,7 +6,7 @@ You will add a basemap picker and legend, and configure the Neighborhood layer p
 
 A continuous color ramp renderer will be used, and the color ramp will be automatically selected by Smart Mapping to best suit the underlying basemap.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, add the basemap picker and legend `div` elements:
  

--- a/develop/style_feature_layers_jsapi.md
+++ b/develop/style_feature_layers_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you will apply custom styling to a feature layer.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition.
 

--- a/develop/style_feature_layers_json_jsapi.md
+++ b/develop/style_feature_layers_json_jsapi.md
@@ -4,7 +4,7 @@ In this lab you will apply custom styling to a feature layer using the JSON Draw
 
 1. Click [this layer](http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/PDX_Neighborhoods_Styled/FeatureServer/0) and copy the Drawing Info JSON. You will use this to style your layer below.
 
-2. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+2. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 3. In `JSBin` > `HTML`, update the `require` statement and function definition:
 

--- a/develop/style_simple_popup_jsapi.md
+++ b/develop/style_simple_popup_jsapi.md
@@ -2,7 +2,7 @@
 
 In this lab you will use code to style a popup.
 
-1. Click [starter_map_jsapi.html](src/starter_map_jsapi.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
+1. Click [starter_map_jsapi3.html](src/starter_map_jsapi3.html) and copy the contents to a new [jsbin.com](http://jsbin.com).
 
 2. In `JSBin` > `HTML`, update the `require` statement and function definition:
 


### PR DESCRIPTION
Replace references to `starter_map_jsapi.html` in legacy 3.x labs with references to `starter_map_jsapi3.html`.

`starter_map_jsapi.html` is now part of a 4.0 lab.
