### PR TITLE
Changed Walking Distance to Walking Time

### DIFF
--- a/data/create_walk_areas/lab.md
+++ b/data/create_walk_areas/lab.md
@@ -18,7 +18,7 @@ In this lab you will take rail stations and see what's within half a mile's walk
 
 4. Click `PDX Rail Stops` > `Perform Analysis` > `Use Proximity` > `Create Drive-Time Areas`.
 
-	a. Choose `Walking Distance` and set the size to `15` `Minutes`.
+	a. Choose `Walking Time` and set the size to `15` `Minutes`.
 
 	b. Select `Dissolve`.
 


### PR DESCRIPTION
The distance default I see is Miles. Walking 15 minutes to a rail stop
is more likely than walking 15 miles, so I assume we meant time instead
of distance here.
